### PR TITLE
Leave absolute paths and URLs as-is

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ var isAbsolute = function(p) {
 var rebaseUrls = function(css, options) {
     return rework(css)
         .use(rework.url(function(url){
-            if (isAbsolute(url) && validator.isURL(url)) {
+            if (isAbsolute(url) || validator.isURL(url)) {
                 return url;
             }
             var absolutePath = path.join(options.currentDir, url)


### PR DESCRIPTION
In other words, only process relative paths.

Originally proposed at https://github.com/kjbekkelund/gulp-css-rebase-urls/issues/4.
