### PR TITLE
Fix for absolute urls handling on win32 platform.

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,6 +9,9 @@ var validator = require('validator');
 var isAbsolute = function (p) {
   var normal = path.normalize(p);
   var absolute = path.resolve(p);
+  if (process.platform === 'win32') {
+    absolute = absolute.substr(2);
+  }
   return normal === absolute;
 };
 


### PR DESCRIPTION
Absolute URLs was not detected when running on win32 because path.resolve() includes "drive letter" into result.
