### PR TITLE
Add support for placing processed CSS into a new root directory.

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,11 +36,25 @@ var rebaseUrls = function (css, options) {
 module.exports = function (options) {
   options = options || {};
   var root = options.root || '.';
+  var reroot = options.reroot || '';
 
   return through.obj(function (file, enc, cb) {
+    var fileDir = path.dirname(file.path);
+
+    // Allows placing the processed CSS in a different root directory while
+    // leaving image resources alone.
+    if (reroot) {
+      var rerootPath = path.join(
+        path.relative(root, reroot),
+        path.relative(root, fileDir)
+      );
+    } else {
+      rerootPath = '';
+    }
+
     var css = rebaseUrls(file.contents.toString(), {
-      currentDir: path.dirname(file.path),
-      root: path.join(file.cwd, root)
+      currentDir: fileDir,
+      root: path.join(file.cwd, root, rerootPath)
     });
 
     file.contents = new Buffer(css);

--- a/test/3/expected.css
+++ b/test/3/expected.css
@@ -1,0 +1,15 @@
+.something {
+  background: url("../../img/lol.jpg") no-repeat top left;
+}
+
+.with-external {
+  background: url("http://example.com/test.jpg") no-repeat top left;
+}
+
+.with-absolute {
+  background: url("/Users/kimjoar/dev/gulp-css-img-path/img/lol.jpg") no-repeat top left;
+}
+
+.with-data {
+  background-image: url("data:image/png;base64,iVBORFAKEBASE64");
+}

--- a/test/3/test.css
+++ b/test/3/test.css
@@ -1,0 +1,15 @@
+.something {
+    background: url('../img/lol.jpg') no-repeat top left;
+}
+
+.with-external {
+    background: url('http://example.com/test.jpg') no-repeat top left;
+}
+
+.with-absolute {
+    background: url('/Users/kimjoar/dev/gulp-css-img-path/img/lol.jpg') no-repeat top left;
+}
+
+.with-data {
+    background-image: url(data:image/png;base64,iVBORFAKEBASE64);
+}

--- a/test/test.js
+++ b/test/test.js
@@ -52,4 +52,23 @@ describe('gulp-css-url-rebase', function () {
 
   });
 
+  it('should assert when reroot is specified', function (cb) {
+
+    var stream = cssRebaseUrls({ root: './www', reroot: './www/processed' });
+
+    stream.on('data', function (file) {
+      assert.equal(file.contents.toString('utf8'), read('3/expected.css').toString('utf-8'));
+      cb();
+    });
+
+    stream.write(new gutil.File({
+      base: testPath,
+      path: testPath + '/style.css',
+      contents: read('3/test.css')
+    }));
+
+    stream.end();
+
+  });
+
 });


### PR DESCRIPTION
This allows setting a new root directory for processed css while
maintaining resource directories for images. For example:

Directory structure:

```
 www/
   css/
     index.less
   img/
     test.png
```

File index.less:

``` css
body {
  background: url(../img/test.png);
}
```

Output directory structure:

```
 www/
   css/
     index.less
   img/
     test.png
   processed/
     css/
       index.css
```

Processed index.css:

``` css
body {
  background: url(../../img/test.png);
}
```
