### PR TITLE
Changed logic which checks if the value of css url() is a URL or not

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,10 +15,25 @@ var isAbsolute = function (p) {
   return normal === absolute;
 };
 
+// isURL('http://a.txt') -> true
+// isURL('a.b.com') -> false
+// isURL('//a.txt') -> true
+// isURL('///a.txt') -> false
+var isUrl = function(url) {
+  if (!url) return false;
+
+  // protocol relative URLs
+  if (url.indexOf('//') === 0 && validator.isURL(url, {allow_protocol_relative_urls: true})) {
+    return true;
+  }
+
+  return validator.isURL(url, {require_protocol: true});
+}
+
 var rebaseUrls = function (css, options) {
   return rework(css)
     .use(reworkUrl(function (url) {
-      if (isAbsolute(url) || validator.isURL(url) || /^(data:.*;.*,)/.test(url)) {
+      if (isAbsolute(url) || isUrl(url) || /^(data:.*;.*,)/.test(url)) {
         return url;
       }
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "dependencies": {
     "rework": "^1.0.1",
-    "rework-plugin-url": "^1.0.1",
+    "rework-plugin-url": "^1.1.0",
     "through2": "^0.6.5",
     "validator": "^3.39.0"
   },


### PR DESCRIPTION
This fix changes url('a.png') to be changed to url('assets/a.png') when root option is set to assets.
Prior to the fix url values url('a.png') was not rebased but url('./a.png') was even though both representations are relative URLs pointing to same resource.
